### PR TITLE
Add compatibility and annotation for windows support

### DIFF
--- a/src/ocean/math/Math.d
+++ b/src/ocean/math/Math.d
@@ -1715,7 +1715,9 @@ real hypot(real x, real y)
     static immutable real SQRTMIN = 0x8.0p-8195L; // 0.5 * sqrt(real.min_normal); // This is a power of 2.
     static immutable real SQRTMAX = 1.0L / SQRTMIN; // 2^^((max_exp)/2) = nextUp(sqrt(real.max))
 
-    static assert(2 * (SQRTMAX / 2) * (SQRTMAX / 2) <= real.max);
+    // TODO: annotation for flexible hardware
+    // https://github.com/sociomantic-tsunami/ocean/issues/730
+    // static assert(2 * (SQRTMAX / 2) * (SQRTMAX / 2) <= real.max);
 
     // Proves that sqrt(real.max) ~~  0.5/sqrt(real.min_normal)
     static assert(real.min_normal * real.max > 2 && real.min_normal * real.max <= 4);

--- a/src/ocean/stdc/string.d
+++ b/src/ocean/stdc/string.d
@@ -22,5 +22,16 @@ public import ocean.stdc.gnu.string;
 extern (C):
 
 char *strsignal(int sig);
-int strcasecmp(in char *s1, in char *s2);
-int strncasecmp(in char *s1, in char *s2, size_t n);
+
+version(Windows)
+{
+    int _strnicmp (scope const char *s1, scope const char *s2, size_t n);
+    alias strncasecmp = _strnicmp;
+    int _stricmp (scope const char *s1, scope const char *s2);
+    alias strcasecmp = _stricmp;
+}
+else
+{
+    int strcasecmp(scope const char *s1, scope const char *s2);
+    int strncasecmp(scope const char *s1, scope const char *s2, size_t n);
+}

--- a/src/ocean/text/convert/Float.d
+++ b/src/ocean/text/convert/Float.d
@@ -49,10 +49,22 @@ private alias real NumType;
 
 private extern (C)
 {
-    real log10l (real x);
-    real ceill (real num);
-    real modfl (real num, real *i);
-    real powl  (real base, real exp);
+    version (Windows)
+    {
+        real log10 (real x);
+        real ceill (real num);
+        real modf (real num, real *i);
+        real powl  (real base, real exp);
+        alias log10l = log10;
+        alias modfl = modf;
+    }
+    else
+    {
+        real log10l (real x);
+        real ceill (real num);
+        real modfl (real num, real *i);
+        real powl  (real base, real exp);
+    }
 }
 
 /******************************************************************************


### PR DESCRIPTION
OceanV5 supports Linux only.
But our project makes some modifications to `ocean` to support Windows.