### PR TITLE
Support `scope cstring` in the FormatterSink

### DIFF
--- a/src/ocean/text/convert/Formatter.d
+++ b/src/ocean/text/convert/Formatter.d
@@ -93,7 +93,7 @@ import ocean.meta.codegen.Identifier;
 
 *******************************************************************************/
 
-public alias void delegate(cstring) @safe FormatterSink;
+public alias void delegate(scope cstring) @safe FormatterSink;
 
 /*******************************************************************************
 

--- a/src/ocean/text/convert/Formatter_test.d
+++ b/src/ocean/text/convert/Formatter_test.d
@@ -43,6 +43,22 @@ unittest
     test!("==")(buff[], "42");
 }
 
+// scope cstring
+unittest
+{
+    static struct Foo
+    {
+        int i = 0x2A;
+        void toString (scope void delegate (scope cstring) sink)
+        {
+            sink("Hello void");
+        }
+    }
+
+    Foo f;
+    test!("==")(format("{}", f), "Hello void");
+}
+
 /*******************************************************************************
 
     Original tango Layout unittest, minus changes of behaviour


### PR DESCRIPTION
@Geod24 it can't be this easy, right? I'm trying to think if I missed anything, but I think it shouldn't break any code.